### PR TITLE
Improvement KW_DatabaseStatement

### DIFF
--- a/KrameWork/KW_DatabaseStatement.php
+++ b/KrameWork/KW_DatabaseStatement.php
@@ -67,7 +67,16 @@
 		public function execute()
 		{
 			foreach ($this->values as $key => $value)
-				$this->statement->bindValue($key, $value);
+      			{
+			  $dataType = null;
+			
+			  if(is_int($value))         { $dataType = PDO::PARAM_INT; }
+			  elseif (is_bool($value))   { $dataType = PDO::PARAM_BOOL; }
+			  elseif (is_null($value))   { $dataType = PDO::PARAM_NULL; }
+			  elseif (is_string($value)) { $dataType = PDO::PARAM_STR; }
+			
+			  $this->statement->bindValue($key, $value, $dataType);
+      			}
 
 			$this->statement->execute();
 			$this->executed = true;
@@ -120,6 +129,14 @@
 		{
 			return count($this->rows);
 		}
+
+    /**
+     * @return string
+     */
+    public function getErrorCode()
+    {
+      return $this->statement->errorCode();
+    }
 
 		/**
 		 * @var array


### PR DESCRIPTION
Allows variables being cast to int, string, bool in PHP to be treated as such in the database