### PR TITLE
By default, only serialize the contained data in containers.

### DIFF
--- a/KrameWork/KW_DataContainer.php
+++ b/KrameWork/KW_DataContainer.php
@@ -28,6 +28,11 @@
 			return array_key_exists($key, $this->values) ? $this->values[$key] : NULL;
 		}
 
+		public function __sleep()
+		{
+			return array('values');
+		}
+
 		/**
 		 * Returns the underlying data as an associative array.
 		 *


### PR DESCRIPTION
Enables rich model objects with PDO objects to be serializeable without extra boilerplate