### PR TITLE
Session thefth protection bug

### DIFF
--- a/KrameWork/KrameSystem.php
+++ b/KrameWork/KrameSystem.php
@@ -46,8 +46,8 @@
 					{
 						if(function_exists('session_abort'))
 						{
-							session_abort();
 							session_regenerate_id(false);
+							session_destroy();
 							session_start();
 						}
 						else


### PR DESCRIPTION
Session needs to be active to change the id, destroy the new one to flush old data.